### PR TITLE
Add background pattern and animation options per theme

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -1,36 +1,60 @@
 const STYLE_ID = 'notion-highlighter-custom-styles';
 
-// Default color values (should match options.js and styles.css for consistency if storage is empty)
-const defaultColors = {
-  gray: { highlight: '#dcdcdc', text: '#000000' },
-  brown: { highlight: '#986a33', text: '#ffffff' },
-  orange: { highlight: '#ff9351', text: '#000000' },
-  yellow: { highlight: '#faff72', text: '#000000' },
-  green: { highlight: '#74de2e', text: '#000000' },
-  blue: { highlight: '#3da5ff', text: '#ffffff' },
-  purple: { highlight: '#bf51e2', text: '#ffffff' },
-  pink: { highlight: '#ff74bc', text: '#ffffff' },
-  red: { highlight: '#ff3737', text: '#ffffff' },
+// Default settings (should match options.js for consistency if storage is empty)
+const defaultSettings = {
+  gray: { highlight: '#dcdcdc', text: '#000000', pattern: 'none', animation: 'none' },
+  brown: { highlight: '#986a33', text: '#ffffff', pattern: 'none', animation: 'none' },
+  orange: { highlight: '#ff9351', text: '#000000', pattern: 'none', animation: 'none' },
+  yellow: { highlight: '#faff72', text: '#000000', pattern: 'none', animation: 'none' },
+  green: { highlight: '#74de2e', text: '#000000', pattern: 'none', animation: 'none' },
+  blue: { highlight: '#3da5ff', text: '#ffffff', pattern: 'none', animation: 'none' },
+  purple: { highlight: '#bf51e2', text: '#ffffff', pattern: 'none', animation: 'none' },
+  pink: { highlight: '#ff74bc', text: '#ffffff', pattern: 'none', animation: 'none' },
+  red: { highlight: '#ff3737', text: '#ffffff', pattern: 'none', animation: 'none' },
 };
 
-// Color blind patterns (extracted from color-blind.html)
-const colorBlindPatterns = {
-  gray: 'repeating-linear-gradient(45deg, #ccc, #ccc 2px, transparent 2px, transparent 5px)',
-  brown: 'repeating-linear-gradient(0deg, #8B4513 0 5px, #D2B48C 5px 10px)',
-  orange:
-    'repeating-linear-gradient(45deg, orange, orange 1px, transparent 1px, transparent 4px), repeating-linear-gradient(-45deg, orange, orange 1px, transparent 1px, transparent 4px)',
-  yellow:
-    'repeating-radial-gradient(circle, #ff0 0px, #ff0 2px, transparent 2px, transparent 6px)',
-  green:
-    'repeating-linear-gradient(90deg, #0f0, #0f0 2px, transparent 2px, transparent 5px)',
-  blue: 'repeating-linear-gradient(0deg, #00f, #00f 2px, transparent 2px, transparent 5px)',
-  purple:
-    'repeating-linear-gradient(135deg, purple, purple 2px, transparent 2px, transparent 5px)',
-  pink: 'repeating-radial-gradient(circle, pink 0 1px, transparent 1px 4px)',
-  red: 'repeating-linear-gradient(0deg, red, red 1px, transparent 1px, transparent 5px), repeating-linear-gradient(90deg, red, red 1px, transparent 1px, transparent 5px)',
+// Mapping Notion's default background RGB values to our theme names
+const notionBgToTheme = {
+  'rgba(248, 248, 247, 1)': 'gray', // Light gray
+  'rgb(248, 248, 247)': 'gray',
+  'rgba(47, 47, 47, 1)': 'gray', // Dark gray
+  'rgb(47, 47, 47)': 'gray',
+  'rgba(244, 238, 238, 1)': 'brown', // Light brown
+  'rgb(244, 238, 238)': 'brown',
+  'rgba(74, 50, 40, 1)': 'brown', // Dark brown
+  'rgb(74, 50, 40)': 'brown',
+  'rgba(251, 236, 221, 1)': 'orange', // Light orange
+  'rgb(251, 236, 221)': 'orange',
+  'rgba(92, 59, 35, 1)': 'orange', // Dark orange
+  'rgb(92, 59, 35)': 'orange',
+  'rgba(251, 243, 219, 1)': 'yellow', // Light yellow
+  'rgb(251, 243, 219)': 'yellow',
+  'rgba(86, 67, 40, 1)': 'yellow', // Dark yellow
+  'rgb(86, 67, 40)': 'yellow',
+  'rgba(237, 243, 236, 1)': 'green', // Light green
+  'rgb(237, 243, 236)': 'green',
+  'rgba(36, 61, 48, 1)': 'green', // Dark green
+  'rgb(36, 61, 48)': 'green',
+  'rgba(231, 243, 248, 1)': 'blue', // Light blue
+  'rgb(231, 243, 248)': 'blue',
+  'rgba(20, 58, 78, 1)': 'blue', // Dark blue
+  'rgb(20, 58, 78)': 'blue',
+  'rgba(248, 243, 252, 1)': 'purple', // Light purple
+  'rgb(248, 243, 252)': 'purple',
+  'rgba(60, 45, 73, 1)': 'purple', // Dark purple
+  'rgb(60, 45, 73)': 'purple',
+  'rgba(252, 241, 246, 1)': 'pink', // Light pink
+  'rgb(252, 241, 246)': 'pink',
+  'rgba(78, 44, 60, 1)': 'pink', // Dark pink
+  'rgb(78, 44, 60)': 'pink',
+  'rgba(253, 235, 236, 1)': 'red', // Light red
+  'rgb(253, 235, 236)': 'red',
+  'rgba(82, 46, 42, 1)': 'red', // Dark red
+  'rgb(82, 46, 42)': 'red',
 };
 
-function applyStyles(colors, colorBlindModeEnabled = false) {
+
+function applyStyles(settings, colorBlindModeEnabled = false, animatedHighlightsEnabled = false) {
   let dynamicStyle = document.getElementById(STYLE_ID);
   if (!dynamicStyle) {
     dynamicStyle = document.createElement('style');
@@ -39,249 +63,111 @@ function applyStyles(colors, colorBlindModeEnabled = false) {
   }
 
   const cssVariables = [];
-  let colorBlindStyles = '';
-
-  for (const theme in colors) {
-    if (colors[theme] && colors[theme].highlight && colors[theme].text) {
+  for (const themeName in settings) {
+    if (settings[themeName] && settings[themeName].highlight && settings[themeName].text) {
       cssVariables.push(
-        `--${theme}-highlight: ${colors[theme].highlight} !important;`,
+        `--${themeName}-highlight: ${settings[themeName].highlight} !important;`,
       );
-      cssVariables.push(`--${theme}-text: ${colors[theme].text} !important;`);
+      cssVariables.push(`--${themeName}-text: ${settings[themeName].text} !important;`);
     }
   }
+  const rootStyles = `:root { ${cssVariables.join(' ')} }`;
+  dynamicStyle.textContent = rootStyles;
 
-  // Add color blind pattern styles if enabled
-  if (colorBlindModeEnabled) {
-    // Add a class to body to enable color blind mode
-    document.body.classList.add('color-blind-mode-active');
-
-    colorBlindStyles = `
-      .color-blind-mode-active .notion-page-content *[style*='background:rgba(248, 248, 247, 1)'],
-      .color-blind-mode-active .notion-page-content *[style*='background:rgba(47, 47, 47, 1)'],
-      .color-blind-mode-active .notion-page-view-discussion *[style*='background:rgba(248, 248, 247, 1)'],
-      .color-blind-mode-active .notion-page-view-discussion *[style*='background:rgba(47, 47, 47, 1)'],
-      .color-blind-mode-active .notion-selectable.notion-page-block *[style*='background: rgb(248, 248, 247)'],
-      .color-blind-mode-active .notion-selectable.notion-page-block *[style*='background: rgb(47, 47, 47)'],
-      .color-blind-mode-active .notion-selectable.notion-text-block *[style*='background:rgba(248, 248, 247, 1)'],
-      .color-blind-mode-active .notion-selectable.notion-text-block *[style*='background:rgba(47, 47, 47, 1)'],
-      .color-blind-mode-active *[placeholder='Add a description…'] *[style*='background:rgba(248, 248, 247, 1)'],
-      .color-blind-mode-active *[placeholder='Add a description…'] *[style*='background:rgba(47, 47, 47, 1)'],
-      .color-blind-mode-active [role='menuitem'] div[style*='background: rgb(248, 248, 247)'],
-      .color-blind-mode-active [role='menuitem'] div[style*='background: rgb(47, 47, 47)'] {
-        background-image: ${colorBlindPatterns.gray} !important;
-        background-size: 10px 10px !important;
-        background-repeat: repeat !important;
-        text-shadow: 0 0 1px #fff, 0 0 2px #fff !important;
-      }
-      
-      .color-blind-mode-active .notion-page-content *[style*='background:rgba(244, 238, 238, 1)'],
-      .color-blind-mode-active .notion-page-content *[style*='background:rgba(74, 50, 40, 1)'],
-      .color-blind-mode-active .notion-page-view-discussion *[style*='background:rgba(244, 238, 238, 1)'],
-      .color-blind-mode-active .notion-page-view-discussion *[style*='background:rgba(74, 50, 40, 1)'],
-      .color-blind-mode-active .notion-selectable.notion-page-block *[style*='background: rgb(244, 238, 238)'],
-      .color-blind-mode-active .notion-selectable.notion-page-block *[style*='background: rgb(74, 50, 40)'],
-      .color-blind-mode-active .notion-selectable.notion-text-block *[style*='background:rgba(244, 238, 238, 1)'],
-      .color-blind-mode-active .notion-selectable.notion-text-block *[style*='background:rgba(74, 50, 40, 1)'],
-      .color-blind-mode-active *[placeholder='Add a description…'] *[style*='background:rgba(244, 238, 238, 1)'],
-      .color-blind-mode-active *[placeholder='Add a description…'] *[style*='background:rgba(74, 50, 40, 1)'],
-      .color-blind-mode-active [role='menuitem'] div[style*='background: rgb(244, 238, 238)'],
-      .color-blind-mode-active [role='menuitem'] div[style*='background: rgb(74, 50, 40)'] {
-        background-image: ${colorBlindPatterns.brown} !important;
-        background-size: 10px 10px !important;
-        background-repeat: repeat !important;
-        text-shadow: 0 0 1px #fff, 0 0 2px #fff !important;
-      }
-      
-      .color-blind-mode-active .notion-page-content *[style*='background:rgba(251, 236, 221, 1)'],
-      .color-blind-mode-active .notion-page-content *[style*='background:rgba(92, 59, 35, 1)'],
-      .color-blind-mode-active .notion-page-view-discussion *[style*='background:rgba(251, 236, 221, 1)'],
-      .color-blind-mode-active .notion-page-view-discussion *[style*='background:rgba(92, 59, 35, 1)'],
-      .color-blind-mode-active .notion-selectable.notion-page-block *[style*='background: rgb(251, 236, 221)'],
-      .color-blind-mode-active .notion-selectable.notion-page-block *[style*='background: rgb(92, 59, 35)'],
-      .color-blind-mode-active .notion-selectable.notion-text-block *[style*='background:rgba(251, 236, 221, 1)'],
-      .color-blind-mode-active .notion-selectable.notion-text-block *[style*='background:rgba(92, 59, 35, 1)'],
-      .color-blind-mode-active *[placeholder='Add a description…'] *[style*='background:rgba(251, 236, 221, 1)'],
-      .color-blind-mode-active *[placeholder='Add a description…'] *[style*='background:rgba(92, 59, 35, 1)'],
-      .color-blind-mode-active [role='menuitem'] div[style*='background: rgb(251, 236, 221)'],
-      .color-blind-mode-active [role='menuitem'] div[style*='background: rgb(92, 59, 35)'] {
-        background-image: ${colorBlindPatterns.orange} !important;
-        background-size: 10px 10px !important;
-        background-repeat: repeat !important;
-        text-shadow: 0 0 1px #fff, 0 0 2px #fff !important;
-      }
-      
-      .color-blind-mode-active .notion-page-content *[style*='background:rgba(251, 243, 219, 1)'],
-      .color-blind-mode-active .notion-page-content *[style*='background:rgba(86, 67, 40, 1)'],
-      .color-blind-mode-active .notion-page-view-discussion *[style*='background:rgba(251, 243, 219, 1)'],
-      .color-blind-mode-active .notion-page-view-discussion *[style*='background:rgba(86, 67, 40, 1)'],
-      .color-blind-mode-active .notion-selectable.notion-page-block *[style*='background: rgb(251, 243, 219)'],
-      .color-blind-mode-active .notion-selectable.notion-page-block *[style*='background: rgb(86, 67, 40)'],
-      .color-blind-mode-active .notion-selectable.notion-text-block *[style*='background:rgba(251, 243, 219, 1)'],
-      .color-blind-mode-active .notion-selectable.notion-text-block *[style*='background:rgba(86, 67, 40, 1)'],
-      .color-blind-mode-active *[placeholder='Add a description…'] *[style*='background:rgba(251, 243, 219, 1)'],
-      .color-blind-mode-active *[placeholder='Add a description…'] *[style*='background:rgba(86, 67, 40, 1)'],
-      .color-blind-mode-active [role='menuitem'] div[style*='background: rgb(251, 243, 219)'],
-      .color-blind-mode-active [role='menuitem'] div[style*='background: rgb(86, 67, 40)'] {
-        background-image: ${colorBlindPatterns.yellow} !important;
-        background-size: 10px 10px !important;
-        background-repeat: repeat !important;
-        text-shadow: 0 0 1px #fff, 0 0 2px #fff !important;
-      }
-      
-      .color-blind-mode-active .notion-page-content *[style*='background:rgba(237, 243, 236, 1)'],
-      .color-blind-mode-active .notion-page-content *[style*='background:rgba(63, 68, 68, 1)'],
-      .color-blind-mode-active .notion-page-view-discussion *[style*='background:rgba(237, 243, 236, 1)'],
-      .color-blind-mode-active .notion-page-view-discussion *[style*='background:rgba(63, 68, 68, 1)'],
-      .color-blind-mode-active .notion-selectable.notion-page-block *[style*='background: rgb(237, 243, 236)'],
-      .color-blind-mode-active .notion-selectable.notion-page-block *[style*='background: rgb(63, 68, 68)'],
-      .color-blind-mode-active .notion-selectable.notion-text-block *[style*='background:rgba(237, 243, 236, 1)'],
-      .color-blind-mode-active .notion-selectable.notion-text-block *[style*='background:rgba(63, 68, 68, 1)'],
-      .color-blind-mode-active *[placeholder='Add a description…'] *[style*='background:rgba(237, 243, 236, 1)'],
-      .color-blind-mode-active *[placeholder='Add a description…'] *[style*='background:rgba(63, 68, 68, 1)'],
-      .color-blind-mode-active [role='menuitem'] div[style*='background: rgb(237, 243, 236)'],
-      .color-blind-mode-active [role='menuitem'] div[style*='background: rgb(63, 68, 68)'] {
-        background-image: ${colorBlindPatterns.green} !important;
-        background-size: 10px 10px !important;
-        background-repeat: repeat !important;
-        text-shadow: 0 0 1px #fff, 0 0 2px #fff !important;
-      }
-      
-      .color-blind-mode-active .notion-page-content *[style*='background:rgba(231, 243, 248, 1)'],
-      .color-blind-mode-active .notion-page-content *[style*='background:rgba(51, 61, 72, 1)'],
-      .color-blind-mode-active .notion-page-view-discussion *[style*='background:rgba(231, 243, 248, 1)'],
-      .color-blind-mode-active .notion-page-view-discussion *[style*='background:rgba(51, 61, 72, 1)'],
-      .color-blind-mode-active .notion-selectable.notion-page-block *[style*='background: rgb(231, 243, 248)'],
-      .color-blind-mode-active .notion-selectable.notion-page-block *[style*='background: rgb(51, 61, 72)'],
-      .color-blind-mode-active .notion-selectable.notion-text-block *[style*='background:rgba(231, 243, 248, 1)'],
-      .color-blind-mode-active .notion-selectable.notion-text-block *[style*='background:rgba(51, 61, 72, 1)'],
-      .color-blind-mode-active *[placeholder='Add a description…'] *[style*='background:rgba(231, 243, 248, 1)'],
-      .color-blind-mode-active *[placeholder='Add a description…'] *[style*='background:rgba(51, 61, 72, 1)'],
-      .color-blind-mode-active [role='menuitem'] div[style*='background: rgb(231, 243, 248)'],
-      .color-blind-mode-active [role='menuitem'] div[style*='background: rgb(51, 61, 72)'] {
-        background-image: ${colorBlindPatterns.blue} !important;
-        background-size: 10px 10px !important;
-        background-repeat: repeat !important;
-        text-shadow: 0 0 1px #fff, 0 0 2px #fff !important;
-      }
-      
-      .color-blind-mode-active .notion-page-content *[style*='background:rgba(248, 243, 252, 1)'],
-      .color-blind-mode-active .notion-page-content *[style*='background:rgba(73, 50, 82, 1)'],
-      .color-blind-mode-active .notion-page-view-discussion *[style*='background:rgba(248, 243, 252, 1)'],
-      .color-blind-mode-active .notion-page-view-discussion *[style*='background:rgba(73, 50, 82, 1)'],
-      .color-blind-mode-active .notion-selectable.notion-page-block *[style*='background: rgb(248, 243, 252)'],
-      .color-blind-mode-active .notion-selectable.notion-page-block *[style*='background: rgb(73, 50, 82)'],
-      .color-blind-mode-active .notion-selectable.notion-text-block *[style*='background:rgba(248, 243, 252, 1)'],
-      .color-blind-mode-active .notion-selectable.notion-text-block *[style*='background:rgba(73, 50, 82, 1)'],
-      .color-blind-mode-active *[placeholder='Add a description…'] *[style*='background:rgba(248, 243, 252, 1)'],
-      .color-blind-mode-active *[placeholder='Add a description…'] *[style*='background:rgba(73, 50, 82, 1)'],
-      .color-blind-mode-active [role='menuitem'] div[style*='background: rgb(248, 243, 252)'],
-      .color-blind-mode-active [role='menuitem'] div[style*='background: rgb(73, 50, 82)'] {
-        background-image: ${colorBlindPatterns.purple} !important;
-        background-size: 10px 10px !important;
-        background-repeat: repeat !important;
-        text-shadow: 0 0 1px #fff, 0 0 2px #fff !important;
-      }
-      
-      .color-blind-mode-active .notion-page-content *[style*='background:rgba(252, 241, 246, 1)'],
-      .color-blind-mode-active .notion-page-content *[style*='background:rgba(83, 59, 76, 1)'],
-      .color-blind-mode-active .notion-page-view-discussion *[style*='background:rgba(252, 241, 246, 1)'],
-      .color-blind-mode-active .notion-page-view-discussion *[style*='background:rgba(83, 59, 76, 1)'],
-      .color-blind-mode-active .notion-selectable.notion-page-block *[style*='background: rgb(252, 241, 246)'],
-      .color-blind-mode-active .notion-selectable.notion-page-block *[style*='background: rgb(83, 59, 76)'],
-      .color-blind-mode-active .notion-selectable.notion-text-block *[style*='background:rgba(252, 241, 246, 1)'],
-      .color-blind-mode-active .notion-selectable.notion-text-block *[style*='background:rgba(83, 59, 76, 1)'],
-      .color-blind-mode-active *[placeholder='Add a description…'] *[style*='background:rgba(252, 241, 246, 1)'],
-      .color-blind-mode-active *[placeholder='Add a description…'] *[style*='background:rgba(83, 59, 76, 1)'],
-      .color-blind-mode-active [role='menuitem'] div[style*='background: rgb(252, 241, 246)'],
-      .color-blind-mode-active [role='menuitem'] div[style*='background: rgb(83, 59, 76)'] {
-        background-image: ${colorBlindPatterns.pink} !important;
-        background-size: 8px 8px !important;
-        background-repeat: repeat !important;
-        text-shadow: 0 0 1px #fff, 0 0 2px #fff !important;
-      }
-      
-      .color-blind-mode-active .notion-page-content *[style*='background:rgba(253, 235, 236, 1)'],
-      .color-blind-mode-active .notion-page-content *[style*='background:rgba(89, 54, 56, 1)'],
-      .color-blind-mode-active .notion-page-view-discussion *[style*='background:rgba(253, 235, 236, 1)'],
-      .color-blind-mode-active .notion-page-view-discussion *[style*='background:rgba(89, 54, 56, 1)'],
-      .color-blind-mode-active .notion-selectable.notion-page-block *[style*='background: rgb(253, 235, 236)'],
-      .color-blind-mode-active .notion-selectable.notion-page-block *[style*='background: rgb(89, 54, 56)'],
-      .color-blind-mode-active .notion-selectable.notion-text-block *[style*='background:rgba(253, 235, 236, 1)'],
-      .color-blind-mode-active .notion-selectable.notion-text-block *[style*='background:rgba(89, 54, 56, 1)'],
-      .color-blind-mode-active *[placeholder='Add a description…'] *[style*='background:rgba(253, 235, 236, 1)'],
-      .color-blind-mode-active *[placeholder='Add a description…'] *[style*='background:rgba(89, 54, 56, 1)'],
-      .color-blind-mode-active [role='menuitem'] div[style*='background: rgb(253, 235, 236)'],
-      .color-blind-mode-active [role='menuitem'] div[style*='background: rgb(89, 54, 56)'] {
-        background-image: ${colorBlindPatterns.red} !important;
-        background-size: 10px 10px !important;
-        background-repeat: repeat !important;
-        text-shadow: 0 0 1px #fff, 0 0 2px #fff !important;
-      }
-    `;
+  // Toggle global animation class on body
+  if (animatedHighlightsEnabled) {
+    document.body.classList.add('animated-highlights-active');
   } else {
-    // Remove the color blind mode class if disabled
+    document.body.classList.remove('animated-highlights-active');
+  }
+
+  // Toggle global color blind mode class on body (for potential text shadow)
+  if (colorBlindModeEnabled) {
+    document.body.classList.add('color-blind-mode-active');
+  } else {
     document.body.classList.remove('color-blind-mode-active');
   }
 
-  const rootStyles = `:root { ${cssVariables.join(' ')} }`;
+  // Apply specific patterns and animations
+  const notionPageContent = document.querySelector('.notion-page-content');
+  if (notionPageContent) {
+    const elementsToStyle = notionPageContent.querySelectorAll('[style*="background:rgba"], [style*="background: rgb"]');
 
-  dynamicStyle.textContent = rootStyles + colorBlindStyles;
-}
+    elementsToStyle.forEach(el => {
+      // Clear previous custom classes to avoid conflicts
+      el.className = el.className.replace(/\bpattern-\S+/g, '').replace(/\banimation-\S+/g, '');
 
-function toggleAnimationClass(enabled) {
-  if (enabled) {
-    document.body.classList.add('animated-highlights-active');
-    console.log('Better Notion Highlights: Animations enabled.');
-  } else {
-    document.body.classList.remove('animated-highlights-active');
-    console.log('Better Notion Highlights: Animations disabled.');
+      const notionBgStyle = el.style.background; // e.g., "rgba(248, 248, 247, 1)" or "rgb(248, 248, 247)"
+
+      // Find the theme name associated with this Notion background color
+      let themeName = null;
+      for (const bg in notionBgToTheme) {
+        if (notionBgStyle.includes(bg)) {
+          themeName = notionBgToTheme[bg];
+          break;
+        }
+      }
+
+      if (themeName && settings[themeName]) {
+        const themeSetting = settings[themeName];
+        // Apply pattern if not 'none' and colorBlindMode is enabled
+        if (colorBlindModeEnabled && themeSetting.pattern && themeSetting.pattern !== 'none') {
+          el.classList.add(`pattern-${themeSetting.pattern}`);
+        }
+        // Apply animation if not 'none' and animatedHighlights are enabled
+        if (animatedHighlightsEnabled && themeSetting.animation && themeSetting.animation !== 'none') {
+          el.classList.add(`animation-${themeSetting.animation}`);
+        }
+      }
+    });
   }
 }
 
+
 // Load initial settings
 chrome.storage.sync.get(
-  ['highlightColors', 'animatedHighlightsEnabled', 'colorBlindModeEnabled'],
+  ['highlightSettings', 'animatedHighlightsEnabled', 'colorBlindModeEnabled'],
   (data) => {
-    const currentColors = data.highlightColors || defaultColors;
-    const colorBlindModeEnabled =
-      data.colorBlindModeEnabled === undefined
-        ? false
-        : data.colorBlindModeEnabled;
+    const currentSettings = data.highlightSettings || defaultSettings;
+    const colorBlindModeEnabled = data.colorBlindModeEnabled || false;
+    const animatedEnabled = data.animatedHighlightsEnabled || false;
 
-    applyStyles(currentColors, colorBlindModeEnabled);
-
-    const animatedEnabled =
-      data.animatedHighlightsEnabled === undefined
-        ? false
-        : data.animatedHighlightsEnabled;
-    toggleAnimationClass(animatedEnabled);
+    applyStyles(currentSettings, colorBlindModeEnabled, animatedEnabled);
   },
 );
 
 // Listen for changes in storage
 chrome.storage.onChanged.addListener((changes, namespace) => {
   if (namespace === 'sync') {
-    // Get current settings to ensure we have all values when one changes
+    // Reload all settings to apply changes correctly
     chrome.storage.sync.get(
-      ['highlightColors', 'colorBlindModeEnabled'],
+      ['highlightSettings', 'animatedHighlightsEnabled', 'colorBlindModeEnabled'],
       (data) => {
-        const currentColors = data.highlightColors || defaultColors;
-        const colorBlindModeEnabled =
-          data.colorBlindModeEnabled === undefined
-            ? false
-            : data.colorBlindModeEnabled;
+        const currentSettings = data.highlightSettings || defaultSettings;
+        const colorBlindModeEnabled = data.colorBlindModeEnabled || false;
+        const animatedEnabled = data.animatedHighlightsEnabled || false;
 
-        if (changes.highlightColors || changes.colorBlindModeEnabled) {
-          applyStyles(currentColors, colorBlindModeEnabled);
-          console.log(
-            'Better Notion Highlights: Highlight colors or color blind mode updated.',
-          );
-        }
-      },
+        applyStyles(currentSettings, colorBlindModeEnabled, animatedEnabled);
+        console.log('Better Notion Highlights: Settings updated.');
+      }
     );
-
-    if (changes.animatedHighlightsEnabled) {
-      toggleAnimationClass(changes.animatedHighlightsEnabled.newValue);
-    }
   }
 });
+
+// Observe DOM changes to re-apply styles if Notion dynamically loads content
+const observer = new MutationObserver((mutationsList, observer) => {
+    // For now, simple re-application on any observed change.
+    // Could be optimized to check if relevant elements were added/changed.
+    chrome.storage.sync.get(
+      ['highlightSettings', 'animatedHighlightsEnabled', 'colorBlindModeEnabled'],
+      (data) => {
+        const currentSettings = data.highlightSettings || defaultSettings;
+        const colorBlindModeEnabled = data.colorBlindModeEnabled || false;
+        const animatedEnabled = data.animatedHighlightsEnabled || false;
+        applyStyles(currentSettings, colorBlindModeEnabled, animatedEnabled);
+      }
+    );
+});
+
+// Start observing the document body for configured mutations
+observer.observe(document.body, { childList: true, subtree: true });

--- a/options.html
+++ b/options.html
@@ -277,7 +277,7 @@
           <div class="card rounded-lg shadow-sm border p-4 flex flex-col items-center">
             <span class="font-semibold text-lg mb-4 pattern-preview gray-pattern"
               style="color: #9ca3af; background-color: #e5e7eb; padding: 2px 8px; border-radius: 4px;">Gray</span>
-            <div class="flex items-center space-x-4">
+            <div class="flex items-center space-x-4 mb-4">
               <div class="flex flex-col items-center">
                 <label class="text-sm font-medium text-muted mb-1" for="gray-bg">Bg</label>
                 <div class="color-picker-wrapper">
@@ -291,11 +291,37 @@
                 </div>
               </div>
             </div>
+            <div class="w-full space-y-2">
+              <div>
+                <label for="gray-pattern" class="block text-sm font-medium text-muted mb-1">Pattern</label>
+                <select id="gray-pattern" name="gray-pattern"
+                  class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
+                  style="color: var(--text-color); background-color: var(--card-background); border-color: var(--border-color);">
+                  <option value="none">None</option>
+                  <option value="stripes">Stripes</option>
+                  <option value="dots">Dots</option>
+                  <option value="diagonal-stripes">Diagonal Stripes</option>
+                  <option value="chevrons">Chevrons</option>
+                </select>
+              </div>
+              <div>
+                <label for="gray-animation" class="block text-sm font-medium text-muted mb-1">Animation</label>
+                <select id="gray-animation" name="gray-animation"
+                  class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
+                  style="color: var(--text-color); background-color: var(--card-background); border-color: var(--border-color);">
+                  <option value="none">None</option>
+                  <option value="pulse">Pulse</option>
+                  <option value="glow">Glow</option>
+                  <option value="color-cycle">Color Cycle</option>
+                  <option value="shake">Shake</option>
+                </select>
+              </div>
+            </div>
           </div>
           <div class="card rounded-lg shadow-sm border p-4 flex flex-col items-center">
             <span class="font-semibold text-lg mb-4 pattern-preview brown-pattern"
               style="color: #a16207; background-color: #fde68a; padding: 2px 8px; border-radius: 4px;">Brown</span>
-            <div class="flex items-center space-x-4">
+            <div class="flex items-center space-x-4 mb-4">
               <div class="flex flex-col items-center">
                 <label class="text-sm font-medium text-muted mb-1" for="brown-bg">Bg</label>
                 <div class="color-picker-wrapper"><input class="color-picker-input" id="brown-bg" type="color"
@@ -307,11 +333,37 @@
                     value="#a16207" /></div>
               </div>
             </div>
+            <div class="w-full space-y-2">
+              <div>
+                <label for="brown-pattern" class="block text-sm font-medium text-muted mb-1">Pattern</label>
+                <select id="brown-pattern" name="brown-pattern"
+                  class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
+                  style="color: var(--text-color); background-color: var(--card-background); border-color: var(--border-color);">
+                  <option value="none">None</option>
+                  <option value="stripes">Stripes</option>
+                  <option value="dots">Dots</option>
+                  <option value="diagonal-stripes">Diagonal Stripes</option>
+                  <option value="chevrons">Chevrons</option>
+                </select>
+              </div>
+              <div>
+                <label for="brown-animation" class="block text-sm font-medium text-muted mb-1">Animation</label>
+                <select id="brown-animation" name="brown-animation"
+                  class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
+                  style="color: var(--text-color); background-color: var(--card-background); border-color: var(--border-color);">
+                  <option value="none">None</option>
+                  <option value="pulse">Pulse</option>
+                  <option value="glow">Glow</option>
+                  <option value="color-cycle">Color Cycle</option>
+                  <option value="shake">Shake</option>
+                </select>
+              </div>
+            </div>
           </div>
           <div class="card rounded-lg shadow-sm border p-4 flex flex-col items-center">
             <span class="font-semibold text-lg mb-4 pattern-preview orange-pattern"
               style="color: #c2410c; background-color: #ffedd5; padding: 2px 8px; border-radius: 4px;">Orange</span>
-            <div class="flex items-center space-x-4">
+            <div class="flex items-center space-x-4 mb-4">
               <div class="flex flex-col items-center">
                 <label class="text-sm font-medium text-muted mb-1" for="orange-bg">Bg</label>
                 <div class="color-picker-wrapper"><input class="color-picker-input" id="orange-bg" type="color"
@@ -323,11 +375,37 @@
                     value="#c2410c" /></div>
               </div>
             </div>
+            <div class="w-full space-y-2">
+              <div>
+                <label for="orange-pattern" class="block text-sm font-medium text-muted mb-1">Pattern</label>
+                <select id="orange-pattern" name="orange-pattern"
+                  class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
+                  style="color: var(--text-color); background-color: var(--card-background); border-color: var(--border-color);">
+                  <option value="none">None</option>
+                  <option value="stripes">Stripes</option>
+                  <option value="dots">Dots</option>
+                  <option value="diagonal-stripes">Diagonal Stripes</option>
+                  <option value="chevrons">Chevrons</option>
+                </select>
+              </div>
+              <div>
+                <label for="orange-animation" class="block text-sm font-medium text-muted mb-1">Animation</label>
+                <select id="orange-animation" name="orange-animation"
+                  class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
+                  style="color: var(--text-color); background-color: var(--card-background); border-color: var(--border-color);">
+                  <option value="none">None</option>
+                  <option value="pulse">Pulse</option>
+                  <option value="glow">Glow</option>
+                  <option value="color-cycle">Color Cycle</option>
+                  <option value="shake">Shake</option>
+                </select>
+              </div>
+            </div>
           </div>
           <div class="card rounded-lg shadow-sm border p-4 flex flex-col items-center">
             <span class="font-semibold text-lg mb-4 pattern-preview yellow-pattern"
               style="color: #ca8a04; background-color: #fef9c3; padding: 2px 8px; border-radius: 4px;">Yellow</span>
-            <div class="flex items-center space-x-4">
+            <div class="flex items-center space-x-4 mb-4">
               <div class="flex flex-col items-center">
                 <label class="text-sm font-medium text-muted mb-1" for="yellow-bg">Bg</label>
                 <div class="color-picker-wrapper"><input class="color-picker-input" id="yellow-bg" type="color"
@@ -339,11 +417,37 @@
                     value="#ca8a04" /></div>
               </div>
             </div>
+            <div class="w-full space-y-2">
+              <div>
+                <label for="yellow-pattern" class="block text-sm font-medium text-muted mb-1">Pattern</label>
+                <select id="yellow-pattern" name="yellow-pattern"
+                  class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
+                  style="color: var(--text-color); background-color: var(--card-background); border-color: var(--border-color);">
+                  <option value="none">None</option>
+                  <option value="stripes">Stripes</option>
+                  <option value="dots">Dots</option>
+                  <option value="diagonal-stripes">Diagonal Stripes</option>
+                  <option value="chevrons">Chevrons</option>
+                </select>
+              </div>
+              <div>
+                <label for="yellow-animation" class="block text-sm font-medium text-muted mb-1">Animation</label>
+                <select id="yellow-animation" name="yellow-animation"
+                  class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
+                  style="color: var(--text-color); background-color: var(--card-background); border-color: var(--border-color);">
+                  <option value="none">None</option>
+                  <option value="pulse">Pulse</option>
+                  <option value="glow">Glow</option>
+                  <option value="color-cycle">Color Cycle</option>
+                  <option value="shake">Shake</option>
+                </select>
+              </div>
+            </div>
           </div>
           <div class="card rounded-lg shadow-sm border p-4 flex flex-col items-center">
             <span class="font-semibold text-lg mb-4 pattern-preview green-pattern"
               style="color: #15803d; background-color: #dcfce7; padding: 2px 8px; border-radius: 4px;">Green</span>
-            <div class="flex items-center space-x-4">
+            <div class="flex items-center space-x-4 mb-4">
               <div class="flex flex-col items-center">
                 <label class="text-sm font-medium text-muted mb-1" for="green-bg">Bg</label>
                 <div class="color-picker-wrapper"><input class="color-picker-input" id="green-bg" type="color"
@@ -355,11 +459,37 @@
                     value="#15803d" /></div>
               </div>
             </div>
+            <div class="w-full space-y-2">
+              <div>
+                <label for="green-pattern" class="block text-sm font-medium text-muted mb-1">Pattern</label>
+                <select id="green-pattern" name="green-pattern"
+                  class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
+                  style="color: var(--text-color); background-color: var(--card-background); border-color: var(--border-color);">
+                  <option value="none">None</option>
+                  <option value="stripes">Stripes</option>
+                  <option value="dots">Dots</option>
+                  <option value="diagonal-stripes">Diagonal Stripes</option>
+                  <option value="chevrons">Chevrons</option>
+                </select>
+              </div>
+              <div>
+                <label for="green-animation" class="block text-sm font-medium text-muted mb-1">Animation</label>
+                <select id="green-animation" name="green-animation"
+                  class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
+                  style="color: var(--text-color); background-color: var(--card-background); border-color: var(--border-color);">
+                  <option value="none">None</option>
+                  <option value="pulse">Pulse</option>
+                  <option value="glow">Glow</option>
+                  <option value="color-cycle">Color Cycle</option>
+                  <option value="shake">Shake</option>
+                </select>
+              </div>
+            </div>
           </div>
           <div class="card rounded-lg shadow-sm border p-4 flex flex-col items-center">
             <span class="font-semibold text-lg mb-4 pattern-preview blue-pattern"
               style="color: #1d4ed8; background-color: #dbeafe; padding: 2px 8px; border-radius: 4px;">Blue</span>
-            <div class="flex items-center space-x-4">
+            <div class="flex items-center space-x-4 mb-4">
               <div class="flex flex-col items-center">
                 <label class="text-sm font-medium text-muted mb-1" for="blue-bg">Bg</label>
                 <div class="color-picker-wrapper"><input class="color-picker-input" id="blue-bg" type="color"
@@ -371,11 +501,37 @@
                     value="#1d4ed8" /></div>
               </div>
             </div>
+            <div class="w-full space-y-2">
+              <div>
+                <label for="blue-pattern" class="block text-sm font-medium text-muted mb-1">Pattern</label>
+                <select id="blue-pattern" name="blue-pattern"
+                  class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
+                  style="color: var(--text-color); background-color: var(--card-background); border-color: var(--border-color);">
+                  <option value="none">None</option>
+                  <option value="stripes">Stripes</option>
+                  <option value="dots">Dots</option>
+                  <option value="diagonal-stripes">Diagonal Stripes</option>
+                  <option value="chevrons">Chevrons</option>
+                </select>
+              </div>
+              <div>
+                <label for="blue-animation" class="block text-sm font-medium text-muted mb-1">Animation</label>
+                <select id="blue-animation" name="blue-animation"
+                  class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
+                  style="color: var(--text-color); background-color: var(--card-background); border-color: var(--border-color);">
+                  <option value="none">None</option>
+                  <option value="pulse">Pulse</option>
+                  <option value="glow">Glow</option>
+                  <option value="color-cycle">Color Cycle</option>
+                  <option value="shake">Shake</option>
+                </select>
+              </div>
+            </div>
           </div>
           <div class="card rounded-lg shadow-sm border p-4 flex flex-col items-center">
             <span class="font-semibold text-lg mb-4 pattern-preview purple-pattern"
               style="color: #7e22ce; background-color: #f3e8ff; padding: 2px 8px; border-radius: 4px;">Purple</span>
-            <div class="flex items-center space-x-4">
+            <div class="flex items-center space-x-4 mb-4">
               <div class="flex flex-col items-center">
                 <label class="text-sm font-medium text-muted mb-1" for="purple-bg">Bg</label>
                 <div class="color-picker-wrapper"><input class="color-picker-input" id="purple-bg" type="color"
@@ -387,11 +543,37 @@
                     value="#7e22ce" /></div>
               </div>
             </div>
+            <div class="w-full space-y-2">
+              <div>
+                <label for="purple-pattern" class="block text-sm font-medium text-muted mb-1">Pattern</label>
+                <select id="purple-pattern" name="purple-pattern"
+                  class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
+                  style="color: var(--text-color); background-color: var(--card-background); border-color: var(--border-color);">
+                  <option value="none">None</option>
+                  <option value="stripes">Stripes</option>
+                  <option value="dots">Dots</option>
+                  <option value="diagonal-stripes">Diagonal Stripes</option>
+                  <option value="chevrons">Chevrons</option>
+                </select>
+              </div>
+              <div>
+                <label for="purple-animation" class="block text-sm font-medium text-muted mb-1">Animation</label>
+                <select id="purple-animation" name="purple-animation"
+                  class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
+                  style="color: var(--text-color); background-color: var(--card-background); border-color: var(--border-color);">
+                  <option value="none">None</option>
+                  <option value="pulse">Pulse</option>
+                  <option value="glow">Glow</option>
+                  <option value="color-cycle">Color Cycle</option>
+                  <option value="shake">Shake</option>
+                </select>
+              </div>
+            </div>
           </div>
           <div class="card rounded-lg shadow-sm border p-4 flex flex-col items-center">
             <span class="font-semibold text-lg mb-4 pattern-preview pink-pattern"
               style="color: #be185d; background-color: #fce7f3; padding: 2px 8px; border-radius: 4px;">Pink</span>
-            <div class="flex items-center space-x-4">
+            <div class="flex items-center space-x-4 mb-4">
               <div class="flex flex-col items-center">
                 <label class="text-sm font-medium text-muted mb-1" for="pink-bg">Bg</label>
                 <div class="color-picker-wrapper"><input class="color-picker-input" id="pink-bg" type="color"
@@ -403,11 +585,37 @@
                     value="#be185d" /></div>
               </div>
             </div>
+            <div class="w-full space-y-2">
+              <div>
+                <label for="pink-pattern" class="block text-sm font-medium text-muted mb-1">Pattern</label>
+                <select id="pink-pattern" name="pink-pattern"
+                  class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
+                  style="color: var(--text-color); background-color: var(--card-background); border-color: var(--border-color);">
+                  <option value="none">None</option>
+                  <option value="stripes">Stripes</option>
+                  <option value="dots">Dots</option>
+                  <option value="diagonal-stripes">Diagonal Stripes</option>
+                  <option value="chevrons">Chevrons</option>
+                </select>
+              </div>
+              <div>
+                <label for="pink-animation" class="block text-sm font-medium text-muted mb-1">Animation</label>
+                <select id="pink-animation" name="pink-animation"
+                  class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
+                  style="color: var(--text-color); background-color: var(--card-background); border-color: var(--border-color);">
+                  <option value="none">None</option>
+                  <option value="pulse">Pulse</option>
+                  <option value="glow">Glow</option>
+                  <option value="color-cycle">Color Cycle</option>
+                  <option value="shake">Shake</option>
+                </select>
+              </div>
+            </div>
           </div>
           <div class="card rounded-lg shadow-sm border p-4 flex flex-col items-center">
             <span class="font-semibold text-lg mb-4 pattern-preview red-pattern"
               style="color: #b91c1c; background-color: #fee2e2; padding: 2px 8px; border-radius: 4px;">Red</span>
-            <div class="flex items-center space-x-4">
+            <div class="flex items-center space-x-4 mb-4">
               <div class="flex flex-col items-center">
                 <label class="text-sm font-medium text-muted mb-1" for="red-bg">Bg</label>
                 <div class="color-picker-wrapper"><input class="color-picker-input" id="red-bg" type="color"
@@ -417,6 +625,32 @@
                 <label class="text-sm font-medium text-muted mb-1" for="red-text">Text</label>
                 <div class="color-picker-wrapper"><input class="color-picker-input" id="red-text" type="color"
                     value="#b91c1c" /></div>
+              </div>
+            </div>
+            <div class="w-full space-y-2">
+              <div>
+                <label for="red-pattern" class="block text-sm font-medium text-muted mb-1">Pattern</label>
+                <select id="red-pattern" name="red-pattern"
+                  class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
+                  style="color: var(--text-color); background-color: var(--card-background); border-color: var(--border-color);">
+                  <option value="none">None</option>
+                  <option value="stripes">Stripes</option>
+                  <option value="dots">Dots</option>
+                  <option value="diagonal-stripes">Diagonal Stripes</option>
+                  <option value="chevrons">Chevrons</option>
+                </select>
+              </div>
+              <div>
+                <label for="red-animation" class="block text-sm font-medium text-muted mb-1">Animation</label>
+                <select id="red-animation" name="red-animation"
+                  class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
+                  style="color: var(--text-color); background-color: var(--card-background); border-color: var(--border-color);">
+                  <option value="none">None</option>
+                  <option value="pulse">Pulse</option>
+                  <option value="glow">Glow</option>
+                  <option value="color-cycle">Color Cycle</option>
+                  <option value="shake">Shake</option>
+                </select>
               </div>
             </div>
           </div>

--- a/styles.css
+++ b/styles.css
@@ -40,24 +40,70 @@
   --menu-font-weight: bold;
 }
 
+/* --- Patterns --- */
+.pattern-stripes {
+  background-image: repeating-linear-gradient(
+    45deg,
+    rgba(0,0,0,0.1),
+    rgba(0,0,0,0.1) 10px,
+    transparent 10px,
+    transparent 20px
+  ) !important;
+}
+
+.pattern-dots {
+  background-image: radial-gradient(
+    rgba(0,0,0,0.1) 2px,
+    transparent 2px
+  ) !important;
+  background-size: 10px 10px !important;
+}
+
+.pattern-diagonal-stripes {
+  background-image: repeating-linear-gradient(
+    -45deg,
+    rgba(0,0,0,0.1),
+    rgba(0,0,0,0.1) 5px,
+    transparent 5px,
+    transparent 10px
+  ) !important;
+}
+
+.pattern-chevrons {
+  background-image: linear-gradient(45deg, rgba(0,0,0,0.1) 25%, transparent 25%),
+                    linear-gradient(-45deg, rgba(0,0,0,0.1) 25%, transparent 25%),
+                    linear-gradient(45deg, transparent 75%, rgba(0,0,0,0.1) 75%),
+                    linear-gradient(-45deg, transparent 75%, rgba(0,0,0,0.1) 75%) !important;
+  background-size: 10px 10px !important;
+  background-position: 0 0, 0 5px, 5px -5px, -5px 0px !important;
+}
+
+
 /* --- Animations --- */
 
-@keyframes subtlePulse {
+@keyframes animation-pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.7; }
 }
 
-@keyframes colorCycle {
+@keyframes animation-color-cycle {
   0%, 100% { filter: brightness(100%); }
   25% { filter: brightness(110%) saturate(120%); }
   50% { filter: brightness(90%) saturate(80%); }
   75% { filter: brightness(105%) saturate(110%); }
 }
 
-@keyframes gentleGlow {
+@keyframes animation-glow {
   0%, 100% { box-shadow: 0 0 5px 0px transparent; }
   50% { box-shadow: 0 0 10px 3px var(--current-highlight-glow, rgba(255,255,255,0.5)); } /* Glow color can be theme-specific */
 }
+
+@keyframes animation-shake {
+  0%, 100% { transform: translateX(0); }
+  10%, 30%, 50%, 70%, 90% { transform: translateX(-2px); }
+  20%, 40%, 60%, 80% { transform: translateX(2px); }
+}
+
 
 /* Gray theme */
 .notion-page-content *[style*='background:rgba(248, 248, 247, 1)'],
@@ -86,32 +132,32 @@
 .animated-highlights-active .notion-selectable.notion-page-block *[style*='background: rgb(47, 47, 47)'],
 .animated-highlights-active .notion-selectable.notion-text-block
   *[style*='background:rgba(248, 248, 247, 1)'],
-.animated-highlights-active .notion-selectable.notion-text-block *[style*='background:rgba(47, 47, 47, 1)'],
+.animated-highlights-active .notion-selectable.notion-text-block *[style*='background:rgba(47, 47, 47, 1)'].animation-pulse,
 .animated-highlights-active *[placeholder='Add a description…']
-  *[style*='background:rgba(248, 248, 247, 1)'],
-.animated-highlights-active *[placeholder='Add a description…'] *[style*='background:rgba(47, 47, 47, 1)'],
-.animated-highlights-active [role='menuitem'] div[style*='background: rgb(248, 248, 247)'],
-.animated-highlights-active [role='menuitem'] div[style*='background: rgb(47, 47, 47)'] {
-  animation: subtlePulse 2s infinite ease-in-out;
+  *[style*='background:rgba(248, 248, 247, 1)'].animation-pulse,
+.animated-highlights-active *[placeholder='Add a description…'] *[style*='background:rgba(47, 47, 47, 1)'].animation-pulse,
+.animated-highlights-active [role='menuitem'] div[style*='background: rgb(248, 248, 247)'].animation-pulse,
+.animated-highlights-active [role='menuitem'] div[style*='background: rgb(47, 47, 47)'].animation-pulse {
+  animation: animation-pulse 2s infinite ease-in-out;
 }
 
 
 /* Brown theme */
-.animated-highlights-active .notion-page-content *[style*='background:rgba(244, 238, 238, 1)'],
-.animated-highlights-active .notion-page-content *[style*='background:rgba(74, 50, 40, 1)'],
-.animated-highlights-active .notion-page-view-discussion *[style*='background:rgba(244, 238, 238, 1)'],
-.animated-highlights-active .notion-page-view-discussion *[style*='background:rgba(74, 50, 40, 1)'],
-.animated-highlights-active .notion-selectable.notion-page-block *[style*='background: rgb(244, 238, 238)'],
-.animated-highlights-active .notion-selectable.notion-page-block *[style*='background: rgb(74, 50, 40)'],
+.animated-highlights-active .notion-page-content *[style*='background:rgba(244, 238, 238, 1)'].animation-color-cycle,
+.animated-highlights-active .notion-page-content *[style*='background:rgba(74, 50, 40, 1)'].animation-color-cycle,
+.animated-highlights-active .notion-page-view-discussion *[style*='background:rgba(244, 238, 238, 1)'].animation-color-cycle,
+.animated-highlights-active .notion-page-view-discussion *[style*='background:rgba(74, 50, 40, 1)'].animation-color-cycle,
+.animated-highlights-active .notion-selectable.notion-page-block *[style*='background: rgb(244, 238, 238)'].animation-color-cycle,
+.animated-highlights-active .notion-selectable.notion-page-block *[style*='background: rgb(74, 50, 40)'].animation-color-cycle,
 .animated-highlights-active .notion-selectable.notion-text-block
-  *[style*='background:rgba(244, 238, 238, 1)'],
-.animated-highlights-active .notion-selectable.notion-text-block *[style*='background:rgba(74, 50, 40, 1)'],
+  *[style*='background:rgba(244, 238, 238, 1)'].animation-color-cycle,
+.animated-highlights-active .notion-selectable.notion-text-block *[style*='background:rgba(74, 50, 40, 1)'].animation-color-cycle,
 .animated-highlights-active *[placeholder='Add a description…']
-  *[style*='background:rgba(244, 238, 238, 1)'],
-.animated-highlights-active *[placeholder='Add a description…'] *[style*='background:rgba(74, 50, 40, 1)'],
-.animated-highlights-active [role='menuitem'] div[style*='background: rgb(244, 238, 238)'],
-.animated-highlights-active [role='menuitem'] div[style*='background: rgb(74, 50, 40)'] {
-  animation: colorCycle 3s infinite linear;
+  *[style*='background:rgba(244, 238, 238, 1)'].animation-color-cycle,
+.animated-highlights-active *[placeholder='Add a description…'] *[style*='background:rgba(74, 50, 40, 1)'].animation-color-cycle,
+.animated-highlights-active [role='menuitem'] div[style*='background: rgb(244, 238, 238)'].animation-color-cycle,
+.animated-highlights-active [role='menuitem'] div[style*='background: rgb(74, 50, 40)'].animation-color-cycle {
+  animation: animation-color-cycle 3s infinite linear;
 }
 
 .notion-page-content *[style*='background:rgba(244, 238, 238, 1)'],
@@ -160,13 +206,13 @@
 .animated-highlights-active .notion-selectable.notion-page-block *[style*='background: rgb(92, 59, 35)'],
 .animated-highlights-active .notion-selectable.notion-text-block
   *[style*='background:rgba(251, 236, 221, 1)'],
-.animated-highlights-active .notion-selectable.notion-text-block *[style*='background:rgba(92, 59, 35, 1)'],
+.animated-highlights-active .notion-selectable.notion-text-block *[style*='background:rgba(92, 59, 35, 1)'].animation-glow,
 .animated-highlights-active *[placeholder='Add a description…']
-  *[style*='background:rgba(251, 236, 221, 1)'],
-.animated-highlights-active *[placeholder='Add a description…'] *[style*='background:rgba(92, 59, 35, 1)'],
-.animated-highlights-active [role='menuitem'] div[style*='background: rgb(251, 236, 221)'],
-.animated-highlights-active [role='menuitem'] div[style*='background: rgb(92, 59, 35)'] {
-  animation: gentleGlow 2.2s infinite alternate;
+  *[style*='background:rgba(251, 236, 221, 1)'].animation-glow,
+.animated-highlights-active *[placeholder='Add a description…'] *[style*='background:rgba(92, 59, 35, 1)'].animation-glow,
+.animated-highlights-active [role='menuitem'] div[style*='background: rgb(251, 236, 221)'].animation-glow,
+.animated-highlights-active [role='menuitem'] div[style*='background: rgb(92, 59, 35)'].animation-glow {
+  animation: animation-glow 2.2s infinite alternate;
 }
 
 /* Yellow theme */
@@ -196,13 +242,13 @@
 .animated-highlights-active .notion-selectable.notion-page-block *[style*='background: rgb(86, 67, 40)'],
 .animated-highlights-active .notion-selectable.notion-text-block
   *[style*='background:rgba(251, 243, 219, 1)'],
-.animated-highlights-active .notion-selectable.notion-text-block *[style*='background:rgba(86, 67, 40, 1)'],
+.animated-highlights-active .notion-selectable.notion-text-block *[style*='background:rgba(86, 67, 40, 1)'].animation-pulse,
 .animated-highlights-active *[placeholder='Add a description…']
-  *[style*='background:rgba(251, 243, 219, 1)'],
-.animated-highlights-active *[placeholder='Add a description…'] *[style*='background:rgba(86, 67, 40, 1)'],
-.animated-highlights-active [role='menuitem'] div[style*='background: rgb(251, 243, 219)'],
-.animated-highlights-active [role='menuitem'] div[style*='background: rgb(86, 67, 40)'] {
-  animation: subtlePulse 2.5s infinite ease-in-out;
+  *[style*='background:rgba(251, 243, 219, 1)'].animation-pulse,
+.animated-highlights-active *[placeholder='Add a description…'] *[style*='background:rgba(86, 67, 40, 1)'].animation-pulse,
+.animated-highlights-active [role='menuitem'] div[style*='background: rgb(251, 243, 219)'].animation-pulse,
+.animated-highlights-active [role='menuitem'] div[style*='background: rgb(86, 67, 40)'].animation-pulse {
+  animation: animation-pulse 2.5s infinite ease-in-out;
 }
 
 /* Green theme */
@@ -232,13 +278,13 @@
 .animated-highlights-active .notion-selectable.notion-page-block *[style*='background: rgb(36, 61, 48)'],
 .animated-highlights-active .notion-selectable.notion-text-block
   *[style*='background:rgba(237, 243, 236, 1)'],
-.animated-highlights-active .notion-selectable.notion-text-block *[style*='background:rgba(36, 61, 48, 1)'],
+.animated-highlights-active .notion-selectable.notion-text-block *[style*='background:rgba(36, 61, 48, 1)'].animation-color-cycle,
 .animated-highlights-active *[placeholder='Add a description…']
-  *[style*='background:rgba(237, 243, 236, 1)'],
-.animated-highlights-active *[placeholder='Add a description…'] *[style*='background:rgba(36, 61, 48, 1)'],
-.animated-highlights-active [role='menuitem'] div[style*='background: rgb(237, 243, 236)'],
-.animated-highlights-active [role='menuitem'] div[style*='background: rgb(36, 61, 48)'] {
-  animation: colorCycle 3.5s infinite linear;
+  *[style*='background:rgba(237, 243, 236, 1)'].animation-color-cycle,
+.animated-highlights-active *[placeholder='Add a description…'] *[style*='background:rgba(36, 61, 48, 1)'].animation-color-cycle,
+.animated-highlights-active [role='menuitem'] div[style*='background: rgb(237, 243, 236)'].animation-color-cycle,
+.animated-highlights-active [role='menuitem'] div[style*='background: rgb(36, 61, 48)'].animation-color-cycle {
+  animation: animation-color-cycle 3.5s infinite linear;
 }
 
 /* Blue theme */
@@ -269,13 +315,13 @@
 .animated-highlights-active .notion-selectable.notion-page-block *[style*='background: rgb(20, 58, 78)'],
 .animated-highlights-active .notion-selectable.notion-text-block
   *[style*='background:rgba(231, 243, 248, 1)'],
-.animated-highlights-active .notion-selectable.notion-text-block *[style*='background:rgba(20, 58, 78, 1)'],
+.animated-highlights-active .notion-selectable.notion-text-block *[style*='background:rgba(20, 58, 78, 1)'].animation-glow,
 .animated-highlights-active *[placeholder='Add a description…']
-  *[style*='background:rgba(231, 243, 248, 1)'],
-.animated-highlights-active *[placeholder='Add a description…'] *[style*='background:rgba(20, 58, 78, 1)'],
-.animated-highlights-active [role='menuitem'] div[style*='background: rgb(231, 243, 248)'],
-.animated-highlights-active [role='menuitem'] div[style*='background: rgb(20, 58, 78)'] {
-  animation: gentleGlow 2.5s infinite alternate;
+  *[style*='background:rgba(231, 243, 248, 1)'].animation-glow,
+.animated-highlights-active *[placeholder='Add a description…'] *[style*='background:rgba(20, 58, 78, 1)'].animation-glow,
+.animated-highlights-active [role='menuitem'] div[style*='background: rgb(231, 243, 248)'].animation-glow,
+.animated-highlights-active [role='menuitem'] div[style*='background: rgb(20, 58, 78)'].animation-glow {
+  animation: animation-glow 2.5s infinite alternate;
 }
 
 /* Purple theme */
@@ -305,13 +351,13 @@
 .animated-highlights-active .notion-selectable.notion-page-block *[style*='background: rgb(60, 45, 73)'],
 .animated-highlights-active .notion-selectable.notion-text-block
   *[style*='background:rgba(248, 243, 252, 1)'],
-.animated-highlights-active .notion-selectable.notion-text-block *[style*='background:rgba(60, 45, 73, 1)'],
+.animated-highlights-active .notion-selectable.notion-text-block *[style*='background:rgba(60, 45, 73, 1)'].animation-pulse,
 .animated-highlights-active *[placeholder='Add a description…']
-  *[style*='background:rgba(248, 243, 252, 1)'],
-.animated-highlights-active *[placeholder='Add a description…'] *[style*='background:rgba(60, 45, 73, 1)'],
-.animated-highlights-active [role='menuitem'] div[style*='background: rgb(248, 243, 252)'],
-.animated-highlights-active [role='menuitem'] div[style*='background: rgb(60, 45, 73)'] {
-  animation: subtlePulse 1.8s infinite ease-in-out;
+  *[style*='background:rgba(248, 243, 252, 1)'].animation-pulse,
+.animated-highlights-active *[placeholder='Add a description…'] *[style*='background:rgba(60, 45, 73, 1)'].animation-pulse,
+.animated-highlights-active [role='menuitem'] div[style*='background: rgb(248, 243, 252)'].animation-pulse,
+.animated-highlights-active [role='menuitem'] div[style*='background: rgb(60, 45, 73)'].animation-pulse {
+  animation: animation-pulse 1.8s infinite ease-in-out;
 }
 
 /* Pink theme */
@@ -342,13 +388,13 @@
 .animated-highlights-active .notion-selectable.notion-page-block *[style*='background: rgb(78, 44, 60)'],
 .animated-highlights-active .notion-selectable.notion-text-block
   *[style*='background:rgba(252, 241, 246, 1)'],
-.animated-highlights-active .notion-selectable.notion-text-block *[style*='background:rgba(78, 44, 60, 1)'],
+.animated-highlights-active .notion-selectable.notion-text-block *[style*='background:rgba(78, 44, 60, 1)'].animation-glow,
 .animated-highlights-active *[placeholder='Add a description…']
-  *[style*='background:rgba(252, 241, 246, 1)'],
-.animated-highlights-active *[placeholder='Add a description…'] *[style*='background:rgba(78, 44, 60, 1)'],
-.animated-highlights-active [role='menuitem'] div[style*='background: rgb(252, 241, 246)'],
-.animated-highlights-active [role='menuitem'] div[style*='background: rgb(78, 44, 60)'] {
-  animation: gentleGlow 2.8s infinite alternate;
+  *[style*='background:rgba(252, 241, 246, 1)'].animation-glow,
+.animated-highlights-active *[placeholder='Add a description…'] *[style*='background:rgba(78, 44, 60, 1)'].animation-glow,
+.animated-highlights-active [role='menuitem'] div[style*='background: rgb(252, 241, 246)'].animation-glow,
+.animated-highlights-active [role='menuitem'] div[style*='background: rgb(78, 44, 60)'].animation-glow {
+  animation: animation-glow 2.8s infinite alternate;
 }
 
 /* Red theme */
@@ -378,14 +424,21 @@
 .animated-highlights-active .notion-selectable.notion-page-block *[style*='background: rgb(82, 46, 42)'],
 .animated-highlights-active .notion-selectable.notion-text-block
   *[style*='background:rgba(253, 235, 236, 1)'],
-.animated-highlights-active .notion-selectable.notion-text-block *[style*='background:rgba(82, 46, 42, 1)'],
+.animated-highlights-active .notion-selectable.notion-text-block *[style*='background:rgba(82, 46, 42, 1)'].animation-color-cycle,
 .animated-highlights-active *[placeholder='Add a description…']
-  *[style*='background:rgba(253, 235, 236, 1)'],
-.animated-highlights-active *[placeholder='Add a description…'] *[style*='background:rgba(82, 46, 42, 1)'],
-.animated-highlights-active [role='menuitem'] div[style*='background: rgb(253, 235, 236)'],
-.animated-highlights-active [role='menuitem'] div[style*='background: rgb(82, 46, 42)'] {
-  animation: colorCycle 2.8s infinite linear;
+  *[style*='background:rgba(253, 235, 236, 1)'].animation-color-cycle,
+.animated-highlights-active *[placeholder='Add a description…'] *[style*='background:rgba(82, 46, 42, 1)'].animation-color-cycle,
+.animated-highlights-active [role='menuitem'] div[style*='background: rgb(253, 235, 236)'].animation-color-cycle,
+.animated-highlights-active [role='menuitem'] div[style*='background: rgb(82, 46, 42)'].animation-color-cycle {
+  animation: animation-color-cycle 2.8s infinite linear;
 }
+
+/* Generic animation selectors */
+.animation-pulse { animation-name: animation-pulse !important; animation-duration: 2s; animation-iteration-count: infinite; animation-timing-function: ease-in-out; }
+.animation-glow { animation-name: animation-glow !important; animation-duration: 2.2s; animation-iteration-count: infinite; animation-direction: alternate; }
+.animation-color-cycle { animation-name: animation-color-cycle !important; animation-duration: 3s; animation-iteration-count: infinite; animation-timing-function: linear; }
+.animation-shake { animation-name: animation-shake !important; animation-duration: 0.5s; animation-iteration-count: infinite; animation-timing-function: ease-in-out; }
+
 
 /* Enhanced font styling for all menu items */
 [role='menuitem'] div[style*='background: rgb(248, 248, 247)'],


### PR DESCRIPTION
- Modify options.html to include dropdowns for background pattern and animation type for each theme card.
- Update options.js to save, load, and preview these new settings (pattern and animation) for each theme.
- Update styles.css with new CSS classes for various patterns (stripes, dots, etc.) and animations (pulse, glow, shake, etc.), and update existing animation selectors.
- Update content_script.js to apply selected patterns (if Color Blind Mode is enabled) and animations (if Animated Highlights are enabled) to Notion page highlights by adding corresponding CSS classes to the elements. Includes MutationObserver for dynamic content.